### PR TITLE
Fixed solution to use only SimpleImpersonation version 3

### DIFF
--- a/Frends.Community.DownloadFile.Tests/Frends.Community.DownloadFile.Tests.csproj
+++ b/Frends.Community.DownloadFile.Tests/Frends.Community.DownloadFile.Tests.csproj
@@ -36,9 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SimpleImpersonation, Version=2.0.1.27158, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SimpleImpersonation.2.0.1\lib\net40-Client\SimpleImpersonation.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SimpleImpersonation, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleImpersonation.3.0.0\lib\net45\SimpleImpersonation.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/Frends.Community.DownloadFile.Tests/packages.config
+++ b/Frends.Community.DownloadFile.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SimpleImpersonation" version="2.0.1" targetFramework="net45" />
+  <package id="SimpleImpersonation" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/Frends.Community.DownloadFile/Frends.Community.DownloadFile.csproj
+++ b/Frends.Community.DownloadFile/Frends.Community.DownloadFile.csproj
@@ -35,10 +35,6 @@
     <DocumentationFile>bin\Release\Frends.Community.DownloadFile.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SimpleImpersonation, Version=2.0.1.27158, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SimpleImpersonation.2.0.1\lib\net40-Client\SimpleImpersonation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Frends.Community.DownloadFile/Frends.Community.DownloadFile.nuspec
+++ b/Frends.Community.DownloadFile/Frends.Community.DownloadFile.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Frends.Community.DownloadFile</id>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <title>Frends.Community.DownloadFile</title>
     <authors>HiQ Finland</authors>
     <owners />
@@ -10,7 +10,7 @@
     <description>FRENDS community task for downloading files.</description>
     <summary />
     <dependencies>
-      <dependency id="SimpleImpersonation" version="2.0" />
+      <dependency id="SimpleImpersonation" version="3.0.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" />

--- a/Frends.Community.DownloadFile/packages.config
+++ b/Frends.Community.DownloadFile/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SimpleImpersonation" version="2.0.1" targetFramework="net45" />
+  <package id="SimpleImpersonation" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | Version             | Changes                 |
 | ---------------------| ---------------------|
 | 1.0.0 | Initial version of DownloadFile |
-| 1.0.8 | Task now support both SimpleImpersonation 2 and 3. |
+| 1.0.9 | Task now support SimpleImpersonation version 3. |
 
 ## License
 


### PR DESCRIPTION
Fixed solution to use only SimpleImpersonation version 3 because mix between versions is not possible.